### PR TITLE
chore: Add the 'Plex- Watchlisted by' rule to the glossary

### DIFF
--- a/docs/Glossary.md
+++ b/docs/Glossary.md
@@ -215,6 +215,14 @@ The key is used for identification in Yaml rule files.
 - Availability: movies, shows, seasons, episodes
 - Type: text[]
 
+#### Watchlisted by (username)
+
+> List of users that have the Plex item in their watchlist. This rule is experimental and might not work for all use cases.
+
+- Key: Plex.watchlist_isListedByUsers
+- Availability: movies, shows, seasons, episodes
+- Type: text[]
+
 #### Present in amount of other collections (incl. parents)
 
 > The number of collections the Plex item is present in. This will also include collections the parent season and/or episode is present in.


### PR DESCRIPTION
I added a new rule in https://github.com/jorenn92/Maintainerr/pull/1152

The rule itself should still be thoroughly tested before release, though.